### PR TITLE
improve program rendering performance and introduce container loading area

### DIFF
--- a/demo/src/catalog/items/cleaningcart/planner-element.jsx
+++ b/demo/src/catalog/items/cleaningcart/planner-element.jsx
@@ -1,9 +1,9 @@
 import * as Three from 'three';
 import React from 'react';
 
-const WIDTH = 100;
-const DEPTH = 80;
-const HEIGHT = 100;
+const WIDTH = 40;
+const DEPTH = 40;
+const HEIGHT = 60;
 
 const black = new Three.MeshLambertMaterial({color: 0x000000});
 const grey = new Three.MeshLambertMaterial({color: 0xC0C0C0});

--- a/src/catalog/factories/area-factory.jsx
+++ b/src/catalog/factories/area-factory.jsx
@@ -7,6 +7,7 @@ let translator = new Translator();
 
 export default function AreaFactory(name, info, textures) {
 
+
   let areaElement = {
     name,
     prototype: 'areas',
@@ -15,7 +16,7 @@ export default function AreaFactory(name, info, textures) {
       visibility: {
         catalog: false,
         layerElementsVisible: false
-      }
+      },
     },
     properties: {
       patternColor: {
@@ -31,7 +32,7 @@ export default function AreaFactory(name, info, textures) {
         }
       }
     },
-    render2D: function (element, layer, scene) {
+    render2D: function (element, layer) {
       let path = '';
 
       ///print area path
@@ -53,7 +54,13 @@ export default function AreaFactory(name, info, textures) {
 
       let fill = element.selected ? SharedStyle.AREA_MESH_COLOR.selected : element.properties.get('patternColor');
 
-      return (<path d={path} fill={fill} />);
+      return (
+        <path 
+          d={path} 
+          fill={fill}
+          fillOpacity="0.4"
+        />
+      );
     },
 
     render3D: function (element, layer, scene) {

--- a/src/class/item.js
+++ b/src/class/item.js
@@ -76,6 +76,7 @@ class Item{
       state = state.updateIn(['scene', 'layers', layerID, 'items', state.getIn(['drawingSupport','currentID'])], item => item.merge({x, y}));
     }
     else {
+      // if not item is being drawn, make new item with default values
       let { updatedState: stateI, item } = this.create( state, layerID, state.getIn(['drawingSupport','type']), x, y, 200, 100, 0);
       state = Item.select( stateI, layerID, item.id ).updatedState;
       state = state.setIn(['drawingSupport','currentID'], item.id);
@@ -86,9 +87,11 @@ class Item{
 
   static endDrawingItem(state, layerID, x, y) {
     let catalog = state.catalog;
+
     state = this.updateDrawingItem(state, layerID, x, y, catalog).updatedState;
-    state = Layer.unselectAll( state, layerID ).updatedState;
-    state =  state.merge({
+
+    state = state.merge({
+      mode: MODE_IDLE,
       drawingSupport: Map({
         type: state.drawingSupport.get('type')
       })
@@ -116,6 +119,41 @@ class Item{
 
     return { updatedState: state };
   }
+  // checks if the items coordinates are in an area, loading area
+  static isCoordsInLoadingArea(state, layerID, x, y) {
+    const scene = state.get('scene');
+    const areas = scene.getIn(['layers', layerID, 'areas']);
+    
+    if(!areas) return false;
+
+    let isInArea = false;
+    // Use valueSeq() for Immutable.js collections
+    areas.valueSeq().forEach(area => {
+      const areaVertices = area.get('vertices');
+      if(areaVertices) {
+        const coordinates = areaVertices.map(vertexID => {
+          const vertex = scene.getIn(['layers', layerID, 'vertices', vertexID]);
+          return {
+            x: vertex.get('x'),
+            y: vertex.get('y')
+          };
+        }).toJS();
+
+        if (coordinates.length > 0) {
+          let minX = Math.min(...coordinates.map(c => c.x));
+          let maxX = Math.max(...coordinates.map(c => c.x));
+          let minY = Math.min(...coordinates.map(c => c.y));
+          let maxY = Math.max(...coordinates.map(c => c.y));
+
+          if (x >= minX && x <= maxX && y >= minY && y <= maxY) {
+            isInArea = true;
+          }
+        }
+      }
+    });
+
+    return isInArea;
+  }
 
   static updateDraggingItem(state, x, y) {
     let {draggingSupport, scene} = state;
@@ -127,7 +165,10 @@ class Item{
     let originalX = draggingSupport.get('originalX');
     let originalY = draggingSupport.get('originalY');
 
+    //this.logItemsOnLayer(state, layerID);
+
     let item = scene.getIn(['layers', layerID, 'items', itemID]);
+    //console.log('Current item ID:', itemID);
 
     let diffX = startPointX - x;
     let diffY = startPointY - y;
@@ -135,46 +176,57 @@ class Item{
     let newX = originalX - diffX;
     let newY = originalY - diffY;
     
-    // Add snap handling
-    if (state.snapMask && !state.snapMask.isEmpty()) {
-      let itemType = item.get('type');
-      let element = state.catalog.getIn(['elements', itemType]).toJS();
-      let dims = element.info.dimensions;
+    // check if the item is in a loading area
+    let isInArea = this.isCoordsInLoadingArea(state, layerID, newX, newY);
+    // Only if the item is in a loading area do we make snap calculations
+    if (isInArea) {
 
-      // check left side snap
-      let leftSnap = SnapUtils.nearestSnap(state.snapElements, newX - dims.width/2, newY, state.snapMask);
-      if (leftSnap) {
-        newX = leftSnap.point.x + dims.width/2;
-        newY = leftSnap.point.y;
-        state = state.merge({ activeSnapElement: leftSnap.snap });
-      }
+      // snap handling
+      if (state.snapMask && !state.snapMask.isEmpty()) {
 
-      //check right side snap
-      let rightSnap = SnapUtils.nearestSnap(state.snapElements, newX + dims.width/2, newY, state.snapMask);
-      if (rightSnap) {
-        newX = rightSnap.point.x - dims.width/2;
-        newY = rightSnap.point.y;
-        state = state.merge({ activeSnapElement: rightSnap.snap});
-      }
+        
 
-      // check top side snap
-      let topSnap = SnapUtils.nearestSnap(state.snapElements, newX, newY + dims.width/2, state.snapMask);
-      if (topSnap) {
-        // check top side
-        newX = topSnap.point.x;
-        newY = topSnap.point.y - dims.depth/2;
-        state = state.merge({ activeSnapElement: topSnap.snap});
-      }
+        let itemType = item.get('type');
+        let element = state.catalog.getIn(['elements', itemType]).toJS();
+        let dims = element.info.dimensions;
 
-      // check bottom side snap
-      let bottomSnap = SnapUtils.nearestSnap(state.snapElements, newX, newY - dims.width/2, state.snapMask);
-      if (bottomSnap) {
-        newX = bottomSnap.point.x;
-        newY = bottomSnap.point.y + dims.depth/2;
-        state = state.merge({ activeSnapElement: bottomSnap.snap});
+        // check left side snap
+        let leftSnap = SnapUtils.nearestSnap(state.snapElements, newX - dims.width/2, newY, state.snapMask);
+        if (leftSnap) {
+          newX = leftSnap.point.x + dims.width/2;
+          newY = leftSnap.point.y;
+          state = state.merge({ activeSnapElement: leftSnap.snap });
+        }
+
+        //check right side snap
+        let rightSnap = SnapUtils.nearestSnap(state.snapElements, newX + dims.width/2, newY, state.snapMask);
+        if (rightSnap) {
+          newX = rightSnap.point.x - dims.width/2;
+          newY = rightSnap.point.y;
+          state = state.merge({ activeSnapElement: rightSnap.snap});
+        }
+
+        // check top side snap
+        let topSnap = SnapUtils.nearestSnap(state.snapElements, newX, newY + dims.width/2, state.snapMask);
+        if (topSnap) {
+          // check top side
+          newX = topSnap.point.x;
+          newY = topSnap.point.y - dims.depth/2;
+          state = state.merge({ activeSnapElement: topSnap.snap});
+        }
+
+        // check bottom side snap
+        let bottomSnap = SnapUtils.nearestSnap(state.snapElements, newX, newY - dims.width/2, state.snapMask);
+        if (bottomSnap) {
+          newX = bottomSnap.point.x;
+          newY = bottomSnap.point.y + dims.depth/2;
+          state = state.merge({ activeSnapElement: bottomSnap.snap});
+        }
       }
     }
 
+    // Add collision detection here in future
+    
     item = item.merge({
       x: newX,
       y: newY
@@ -277,6 +329,11 @@ class Item{
     itemAttributes = fromJS(itemAttributes);
     return this.setAttributes(state, layerID, itemID, itemAttributes);
   }
+
+  // static logItemsOnLayer(state, layerID) {
+  //   const items = state.getIn(['scene', 'layers', layerID, 'items']);
+  //   console.log('Items on layer:', items.toJS());
+  // }
 
 }
 

--- a/src/models.js
+++ b/src/models.js
@@ -205,9 +205,9 @@ export class Scene extends Record({
   grids: new Map(),
   selectedLayer: null,
   groups: new Map(),
-  width: 15000, // default width
-  height: 9000, // default height
-  meta: new Map(),   //additional info
+  width: 15000,
+  height: 9000,
+  meta: new Map(),
   guides: new Map()
 }, 'Scene') {
   constructor(json = {}) {

--- a/src/utils/snap.js
+++ b/src/utils/snap.js
@@ -99,6 +99,85 @@ export function nearestSnap(snapElements, x, y, snapMask) {
   );
 }
 
+export function nearestGridSnap(state, layerID, x, y) {
+  const scene = state.get('scene');
+    const areas = scene.getIn(['layers', layerID, 'areas']);
+    
+    if(!areas) return false;
+
+    let isInArea = false;
+    // Use valueSeq() for Immutable.js collections
+    areas.valueSeq().forEach(area => {
+      const areaVertices = area.get('vertices');
+      if(areaVertices) {
+        const coordinates = areaVertices.map(vertexID => {
+          const vertex = scene.getIn(['layers', layerID, 'vertices', vertexID]);
+          return {
+            x: vertex.get('x'),
+            y: vertex.get('y')
+          };
+        }).toJS();
+
+        if (coordinates.length > 0) {
+          let minX = Math.min(...coordinates.map(c => c.x));
+          let maxX = Math.max(...coordinates.map(c => c.x));
+          let minY = Math.min(...coordinates.map(c => c.y));
+          let maxY = Math.max(...coordinates.map(c => c.y));
+
+          if (x >= minX && x <= maxX && y >= minY && y <= maxY) {
+            isInArea = true;
+          }
+        }
+      }
+    });
+}
+// export function nearestSnap(snapElements, x, y, snapMask) {
+  
+//   // const isInFilledArea = snapElements 
+//   //   .valueSeq()
+//   //   .filter(el => el.prototype === 'areas')
+//   //   .some(area => area.info.isFilled);
+
+//   // If not in filled area, return no snaps
+//   // if (!isInFilledArea) {
+//   //   return null;
+//   // }
+
+//   // First check if point (x,y) is in any filled area
+//   const areas = snapElements.filter(el => el.prototype === 'areas')
+  
+//   // Check if point x,y is in any of these areas using vertices
+//   const isInFilledArea = areas.some(element => {
+//     // Get vertices and check if x,y is inside the polygon they form
+//     const vertices = element.vertices.map(vertexID => {
+//       let vertex = layer.vertices.get(vertexID);
+//       return {x: vertex.x, y: vertex.y};
+//     });
+//     return pointIsInPolygon(x, y, vertices);
+//   });
+//   // If not in any filled area, return null - no snapping
+//   //if (!isInFilledArea) return null;
+//   // If we are in filled area, proceed with normal snap logic
+//   let filter = {
+//     'point': snapMask.get(SNAP_POINT),
+//     'line': snapMask.get(SNAP_LINE),
+//     'line-segment': snapMask.get(SNAP_SEGMENT),
+//     'grid': snapMask.get(SNAP_GRID)
+//   };
+
+//   return snapElements
+//     .valueSeq()
+//     .filter(el => filter[el.type] && el.isNear(x, y, el.radius))
+//     .map(snap => { return {snap, point: snap.nearestPoint(x, y)} })
+//     .filter(({snap: {radius}, point: {distance}}) => distance < radius)
+//     .min(
+//       (
+//         {snap: { priority : p1 }, point: { distance : d1 }},
+//         {snap: { priority : p2 }, point: { distance : d2 }}
+//       ) => p1 === p2 ? ( d1 < d2 ? -1 : 1 ) : ( p1 > p2 ? -1 : 1 )
+//     );
+// }
+
 export function addPointSnap(snapElements, x, y, radius, priority, related) {
   related = new List([related]);
   return snapElements.push(new PointSnap({x, y, radius, priority, related}));


### PR DESCRIPTION
Snapping of objects only calculated if in a loading area, to reduce lag. Loading area is now an object that can be searched. The GridSnap is still calculating every snap point using the entire SVG, snapElement, this needs to be refined to just the loading area. 
